### PR TITLE
Added headless mode and record video for test command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ ENV/
 # PyInstaller build files
 *.zip
 release.sh
+dummy

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -26,9 +26,12 @@ def test(
     headless: Optional[bool] = typer.Option(
         False, "--headless", help="Run tests in headless mode"
     ),
+    silent: Optional[bool] = typer.Option(
+        False, "--silent", "-s", help="Run in silent mode (less verbose output)"
+    ),
 ):
     """Run Bugster tests. If no path is provided, runs all tests in .bugster/tests."""
-    asyncio.run(test_command(path, headless))
+    asyncio.run(test_command(path, headless, silent))
 
 
 def main():

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -22,10 +22,13 @@ def init():
 
 @app.command()
 def test(
-    path: Optional[str] = typer.Argument(None, help="Path to test file or directory")
+    path: Optional[str] = typer.Argument(None, help="Path to test file or directory"),
+    headless: Optional[bool] = typer.Option(
+        False, "--headless", help="Run tests in headless mode"
+    ),
 ):
     """Run Bugster tests. If no path is provided, runs all tests in .bugster/tests."""
-    asyncio.run(test_command(path))
+    asyncio.run(test_command(path, headless))
 
 
 def main():

--- a/bugster/utils/file.py
+++ b/bugster/utils/file.py
@@ -7,6 +7,8 @@ from typing import Optional, List
 import yaml
 import typer
 from rich.console import Console
+import json
+import tempfile
 
 from bugster.constants import CONFIG_PATH, TESTS_DIR
 from bugster.types import Config
@@ -48,3 +50,19 @@ async def load_test_files(test_path: Optional[Path] = None) -> List[dict]:
                 test_files.append({"file": file, "content": yaml.safe_load(f)})
 
     return test_files
+
+
+def get_mcp_config_path(mcp_config: dict, version: str) -> str:
+    """Get the MCP config file path. Creates a temporary config file with browser settings."""
+
+    # Create a temporary file with a specific name
+    temp_dir = tempfile.gettempdir()
+    config_path = Path(temp_dir) / f"bugster_mcp_{version}.config.json"
+
+    # Only create the file if it doesn't exist
+    if not config_path.exists():
+        # Write the configuration
+        with open(config_path, "w") as f:
+            json.dump(mcp_config, f, indent=2)
+
+    return str(config_path)


### PR DESCRIPTION
- Added a `headless` option to the `test` command for running tests in headless mode.
- Updated `execute_test` to handle headless mode when initializing the MCP client.
- Introduced a new utility function `get_mcp_config_path` to create a temporary MCP configuration file.
- Improved console output formatting for test results and connection status.
- Updated `.gitignore` to include a new entry for `dummy`.
- Added a `silent` option to the `test` command, allowing users to run tests with less verbose output.
- Updated the `handle_step_request` and `execute_test` functions to respect the silent mode, suppressing console messages accordingly.
- Enhanced test execution feedback by conditionally displaying test results and status updates based on the silent mode setting.