### PR TITLE
Release 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Bugster CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.8] - 2025-06-23
+## [0.3.9] - 2025-06-23
 
 ### Added
 - Added `vercel-bypass-automation` support: you can now use the secret within Bugster config while keeping your branch protected
@@ -82,8 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Core specs format and parsing capabilities
 
 
-[Unreleased]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.8...HEAD
-[0.3.8]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.7...v0.3.8
+[Unreleased]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.9...HEAD
+[0.3.9]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.7...v0.3.9
 [0.3.7]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.0...v0.3.6
 [0.3.0]: https://github.com/Bugsterapp/bugster-cli/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Bugster CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2025-06-23
+
+### Added
+- Added `vercel-bypass-automation` support: you can now use the secret within Bugster config while keeping your branch protected
+
 ## [0.3.7] - 2025-06-19
 
 ### Added
@@ -76,7 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project configuration system with YAML-based config files
 - Core specs format and parsing capabilities
 
-[Unreleased]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.7...HEAD
+
+[Unreleased]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.8...HEAD
+[0.3.8]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Bugsterapp/bugster-cli/compare/v0.3.0...v0.3.6
 [0.3.0]: https://github.com/Bugsterapp/bugster-cli/compare/v0.2.0...v0.3.0

--- a/bugster/__init__.py
+++ b/bugster/__init__.py
@@ -2,4 +2,4 @@
 Bugster CLI - A command-line interface tool for managing test cases.
 """
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/bugster/__init__.py
+++ b/bugster/__init__.py
@@ -2,4 +2,4 @@
 Bugster CLI - A command-line interface tool for managing test cases.
 """
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 from setuptools import find_packages, setup
 
 # Read version from bugster/__init__.py
-with open("bugster/__init__.py") as f:
+with open("bugster/__init__.py", encoding="utf-8") as f:
     version_match = re.search(r'__version__ = ["\']([^"\']*)["\']', f.read())
     if version_match:
         version = version_match.group(1)
@@ -78,7 +78,7 @@ setup(
     },
     author="Bugster Team",
     description="A CLI tool for managing test cases",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     keywords="testing, cli, automation",
     python_requires=">=3.10",


### PR DESCRIPTION
## [0.3.8] - 2025-06-23

### Added
- Added `vercel-bypass-automation` support: you can now use the secret within Bugster config while keeping your branch protected
