### PR TITLE
Add --against-default option to update command for comparing against …

### DIFF
--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -266,6 +266,11 @@ def update(
         "--show-logs",
         help="Show detailed logs during analysis",
     ),
+    against_default: bool = typer.Option(
+        False,
+        "--against-default",
+        help="Compare against the default branch instead of HEAD",
+    ),
 ):
     """Update your test specs with the latest changes."""
     from bugster.commands.update import update_command
@@ -275,6 +280,7 @@ def update(
         suggest_only=suggest_only,
         delete_only=delete_only,
         show_logs=show_logs,
+        against_default=against_default,
     )
 
 

--- a/bugster/commands/update.py
+++ b/bugster/commands/update.py
@@ -17,20 +17,24 @@ def update_command(
     suggest_only: bool = False,
     delete_only: bool = False,
     show_logs: bool = False,
+    against_default: bool = False,
 ):
     """Run Bugster CLI update command."""
     # Note: Logger configuration is now handled globally by the CLI
     # The --debug flag controls logging visibility across all commands
     # Legacy show_logs parameter is maintained for backward compatibility but is ignored
 
-    assert (
-        sum([update_only, suggest_only, delete_only]) <= 1
-    ), "At most one of update_only, suggest_only, delete_only can be True"
+    assert sum([update_only, suggest_only, delete_only]) <= 1, (
+        "At most one of update_only, suggest_only, delete_only can be True"
+    )
 
     try:
         console.print("✓ Analyzing code changes...")
         update_service = get_update_service(
-            update_only=update_only, suggest_only=suggest_only, delete_only=delete_only
+            update_only=update_only,
+            suggest_only=suggest_only,
+            delete_only=delete_only,
+            against_default=against_default,
         )
         update_service.run()
     except Exception as err:

--- a/bugster/libs/mixins.py
+++ b/bugster/libs/mixins.py
@@ -94,9 +94,17 @@ class UpdateMixin:
         """Update existing specs."""
         file_paths = self.mapped_changes["modified"]
         console.print(f"✓ Found {len(file_paths)} modified files")
+
+        # Choose git command based on against_default flag
+        git_command = (
+            GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_DEFAULT_LOCAL
+            if getattr(self, "against_default", False)
+            else GitCommand.DIFF_CHANGES_ONLY_MODIFIED
+        )
+
         diff_changes_per_page = get_diff_changes_per_page(
             import_tree=self.import_tree,
-            git_command=GitCommand.DIFF_CHANGES_ONLY_MODIFIED,
+            git_command=git_command,
         )
         affected_pages = diff_changes_per_page.keys()
         updated_specs = 0
@@ -161,8 +169,16 @@ class SuggestMixin:
         """Suggest new specs."""
         file_paths = self.mapped_changes["new"]
         console.print(f"✓ Found {len(file_paths)} added files")
+
+        # Choose git command based on against_default flag
+        git_command = (
+            GitCommand.DIFF_AGAINST_DEFAULT_LOCAL
+            if getattr(self, "against_default", False)
+            else GitCommand.DIFF_HEAD
+        )
+
         diff_changes_per_page = get_diff_changes_per_page(
-            import_tree=self.import_tree, git_command=GitCommand.DIFF_HEAD
+            import_tree=self.import_tree, git_command=git_command
         )
         suggested_specs = []
         affected_pages = diff_changes_per_page.keys()

--- a/bugster/libs/services/update_service.py
+++ b/bugster/libs/services/update_service.py
@@ -9,17 +9,26 @@ from bugster.libs.mixins import (
 )
 from bugster.libs.services.test_cases_service import TestCasesService
 from bugster.libs.utils.enums import GitCommand
-from bugster.libs.utils.git import parse_diff_status, run_git_command
+from bugster.libs.utils.git import (
+    parse_diff_name_status,
+    parse_diff_status,
+    run_git_command,
+)
 from bugster.libs.utils.nextjs.import_tree_generator import generate_import_tree
 
 
 class UpdateService(ABC):
     """Base class for update services."""
 
-    def __init__(self, test_cases_service: Optional["TestCasesService"] = None):
+    def __init__(
+        self,
+        test_cases_service: Optional["TestCasesService"] = None,
+        against_default: bool = False,
+    ):
         self._test_cases_service = test_cases_service
         self._mapped_changes: Optional[dict] = None
         self._import_tree: Optional[dict] = None
+        self.against_default = against_default
 
     @property
     def test_cases_service(self) -> TestCasesService:
@@ -44,8 +53,16 @@ class UpdateService(ABC):
 
     def _get_mapped_changes(self) -> dict:
         """Get the mapped changes of the user's repository."""
-        diff_status = run_git_command(cmd_key=GitCommand.DIFF_STATUS_PORCELAIN)
-        return parse_diff_status(diff_status=diff_status)
+        if self.against_default:
+            # When comparing against default branch, use git diff --name-status
+            diff_status = run_git_command(
+                cmd_key=GitCommand.DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL
+            )
+            return parse_diff_name_status(diff_status=diff_status)
+        else:
+            # Normal behavior: use git status --porcelain
+            diff_status = run_git_command(cmd_key=GitCommand.DIFF_STATUS_PORCELAIN)
+            return parse_diff_status(diff_status=diff_status)
 
     def _get_import_tree(self) -> dict:
         """Get the import tree of the user's repository."""
@@ -104,13 +121,18 @@ class DetectAffectedSpecsService(UpdateService, DetectAffectedSpecsMixin):
         return self.detect()
 
 
-def get_update_service(update_only: bool, suggest_only: bool, delete_only: bool):
+def get_update_service(
+    update_only: bool,
+    suggest_only: bool,
+    delete_only: bool,
+    against_default: bool = False,
+):
     """Get the update service based on the flags."""
     if update_only:
-        return UpdateOnlyService()
+        return UpdateOnlyService(against_default=against_default)
     elif suggest_only:
-        return SuggestOnlyService()
+        return SuggestOnlyService(against_default=against_default)
     elif delete_only:
-        return DeleteOnlyService()
+        return DeleteOnlyService(against_default=against_default)
     else:
-        return DefaultUpdateService()
+        return DefaultUpdateService(against_default=against_default)

--- a/bugster/libs/services/update_service.py
+++ b/bugster/libs/services/update_service.py
@@ -55,10 +55,10 @@ class UpdateService(ABC):
         """Get the mapped changes of the user's repository."""
         if self.against_default:
             # When comparing against default branch, use git diff --name-status
-            diff_status = run_git_command(
+            diff_name_status = run_git_command(
                 cmd_key=GitCommand.DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL
             )
-            return parse_diff_name_status(diff_status=diff_status)
+            return parse_diff_name_status(diff_name_status=diff_name_status)
         else:
             # Normal behavior: use git status --porcelain
             diff_status = run_git_command(cmd_key=GitCommand.DIFF_STATUS_PORCELAIN)

--- a/bugster/libs/utils/enums.py
+++ b/bugster/libs/utils/enums.py
@@ -79,3 +79,30 @@ class GitCommand(list, Enum):
     ]
     DIFF_CACHED = ["git", "diff", "--cached", "--", "*.tsx", "*.ts", "*.js", "*.jsx"]
     RESET = ["git", "reset", "--quiet"]
+    DIFF_AGAINST_DEFAULT_LOCAL = [
+        "bash",
+        "-c",
+        (
+            "git diff "
+            "$(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2) "
+            "-- '*.tsx' '*.ts' '*.js' '*.jsx'"
+        ),
+    ]
+    DIFF_CHANGES_ONLY_MODIFIED_AGAINST_DEFAULT_LOCAL = [
+        "bash",
+        "-c",
+        (
+            "git diff "
+            "$(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2) "
+            "--diff-filter=M -- '*.tsx' '*.ts' '*.js' '*.jsx'"
+        ),
+    ]
+    DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL = [
+        "bash",
+        "-c",
+        (
+            "git diff --name-status "
+            "$(git symbolic-ref --short refs/remotes/origin/HEAD | cut -d'/' -f2) "
+            "-- '*.tsx' '*.ts' '*.js' '*.jsx'"
+        ),
+    ]


### PR DESCRIPTION
…the default branch

This update introduces a new command-line option, --against-default, allowing users to compare changes against the default branch instead of HEAD. The implementation includes adjustments in the update command, update service, and mixins to handle the new comparison logic effectively. Additionally, new Git commands are defined for handling diffs against the default branch.