### PR TITLE
Release v0.3.26

### DIFF
--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -156,6 +156,21 @@ def init(
     )
 
 
+@app.command()
+def auth(
+    api_key: Optional[str] = typer.Option(
+        None, "--api-key", help="Bugster API key to set (starts with 'bugster_')"
+    ),
+    clear: bool = typer.Option(
+        False, "--clear", help="Clear the existing API key"
+    ),
+):
+    """Authenticate with Bugster API key."""
+    from bugster.commands.auth import auth_command
+
+    auth_command(api_key=api_key, clear=clear)
+
+
 def _run_tests(
     path: Optional[str] = typer.Argument(None, help="Path to test file or directory"),
     headless: Optional[bool] = typer.Option(

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -197,7 +197,7 @@ def _run_tests(
         None, "--only-affected", help="Only run tests for affected files or directories"
     ),
     max_concurrent: Optional[int] = typer.Option(
-        5, "--max-concurrent", help="Maximum number of concurrent tests"
+        5, "--max-concurrent", "--parallel", help="Maximum number of concurrent tests"
     ),
     verbose: Optional[bool] = typer.Option(False, "--verbose", help="Verbose output"),
 ):
@@ -399,7 +399,7 @@ def destructive(
     ),
     base_url: Optional[str] = typer.Option(None, help="Override base URL from config"),
     max_concurrent: Optional[int] = typer.Option(
-        None, help="Maximum number of concurrent agents (default: 3)"
+        None, "--max-concurrent", "--parallel", help="Maximum number of concurrent agents (default: 3)"
     ),
     verbose: bool = typer.Option(False, help="Show detailed agent execution logs"),
     run_id: Optional[str] = typer.Option(

--- a/bugster/commands/auth.py
+++ b/bugster/commands/auth.py
@@ -3,22 +3,81 @@ Login command implementation for Bugster CLI.
 """
 
 from rich.console import Console
-from rich.prompt import Prompt, Confirm
-from bugster.analytics import track_command, BugsterAnalytics
-from bugster.utils.user_config import save_api_key
+from rich.prompt import Prompt
+from bugster.analytics import track_command
+from bugster.utils.user_config import save_api_key, get_api_key, load_user_config, save_user_config
 from bugster.utils.console_messages import AuthMessages
 import webbrowser
+from typing import Optional
 
 console = Console()
 
 DASHBOARD_URL = "https://gui.bugster.dev/"  # Update this with your actual dashboard URL
 API_KEY_HINT = "bugster_..."
 
+def clear_api_key():
+    """Remove the API key from the config file."""
+    config = load_user_config()
+    if "apiKey" in config:
+        del config["apiKey"]
+        save_user_config(config)
+        return True
+    return False
+
 @track_command("auth")
-def auth_command():
+def auth_command(api_key: Optional[str] = None, clear: bool = False):
     """Authenticate user with Bugster API key."""
     console.print()
     
+    # Handle --clear flag
+    if clear:
+        existing_key = get_api_key()
+        if existing_key:
+            if clear_api_key():
+                console.print("✅ [green]API key cleared successfully![/green]")
+            else:
+                console.print("❌ [red]Error clearing API key.[/red]")
+        else:
+            console.print("ℹ️  [yellow]No API key found to clear.[/yellow]")
+        return
+    
+    # Clear existing API key before setting new one
+    existing_key = get_api_key()
+    if existing_key:
+        console.print("🔄 [yellow]Removing existing API key...[/yellow]")
+        clear_api_key()
+    
+    # Handle --api-key flag
+    if api_key:
+        # Validate provided API key
+        if not api_key.strip():
+            console.print("❌ [red]API key cannot be empty.[/red]")
+            return
+            
+        if not api_key.startswith("bugster_"):
+            console.print("⚠️  [yellow]Warning: API keys typically start with 'bugster_'[/yellow]")
+            if Prompt.ask(
+                "🤔 Continue anyway?",
+                choices=["y", "n"],
+                default="n"
+            ) == "n":
+                console.print("❌ [red]Authentication cancelled.[/red]")
+                return
+        
+        console.print("🔄 [yellow]Validating API key...[/yellow]")
+        
+        if validate_api_key(api_key):
+            try:
+                save_api_key(api_key)
+                console.print("✅ [green]API key saved successfully![/green]")
+                        
+            except Exception as e:
+                console.print(f"❌ [red]Error saving API key: {str(e)}[/red]")
+        else:
+            console.print("❌ [red]Invalid API key. Please check and try again.[/red]")
+        return
+    
+    # Interactive flow (original behavior)
     # Show authentication panel
     auth_panel = AuthMessages.create_auth_panel()
     console.print(auth_panel)
@@ -37,13 +96,13 @@ def auth_command():
     # Get API key with validation
     while True:
         AuthMessages.api_key_prompt()
-        api_key = Prompt.ask(AuthMessages.get_api_key_prompt()).strip()
+        user_api_key = Prompt.ask(AuthMessages.get_api_key_prompt()).strip()
         
-        if not api_key:
+        if not user_api_key:
             AuthMessages.empty_api_key_error()
             continue
             
-        if not api_key.startswith("bugster_"):
+        if not user_api_key.startswith("bugster_"):
             AuthMessages.invalid_prefix_warning()
             if Prompt.ask(
                 AuthMessages.get_continue_anyway_prompt(),
@@ -54,7 +113,7 @@ def auth_command():
         
         AuthMessages.validating_api_key()
         
-        if validate_api_key(api_key):  
+        if validate_api_key(user_api_key):  
             break
         else:
             AuthMessages.invalid_api_key_error()
@@ -62,29 +121,11 @@ def auth_command():
     
     # Save API key
     try:
-        save_api_key(api_key)
+        save_api_key(user_api_key)
         AuthMessages.auth_success()
     except Exception as e:
         AuthMessages.auth_error(e)
         raise
-
-    # Analytics opt-in/opt-out prompt (only if not already opted out)
-    if not BugsterAnalytics.is_opted_out():
-        analytics_panel = AuthMessages.create_analytics_panel()
-        console.print(analytics_panel)
-        console.print()
-        
-        enable_analytics = Confirm.ask(
-            f"🤔 Would you like to help improve Bugster by sharing anonymous usage analytics?", 
-            default=True
-        )
-        
-        if not enable_analytics:
-            BugsterAnalytics.create_opt_out_file()
-            AuthMessages.analytics_disabled()
-        else:
-            AuthMessages.analytics_enabled()
-        console.print()
 
 def validate_api_key(api_key: str) -> bool:
     """Validate API key by making a test request"""

--- a/bugster/libs/services/run_limits_service.py
+++ b/bugster/libs/services/run_limits_service.py
@@ -158,6 +158,6 @@ def get_test_limit_from_config() -> Optional[int]:
     Returns:
         Maximum number of tests to run, or None if no limit
     """
-    return 5
+    return 10
 
 


### PR DESCRIPTION
## [0.3.26]

### PENDING 
https://linear.app/bugster/issue/DEV-143/cli-init-projectid-handler
https://linear.app/bugster/issue/DEV-216/init-inicializar-con-projectid-existente

### Added
- Added  `bugster auth` command for setting up or cleaning existing api key
- Added  `-- parallel` for  `bugster run` command. Accept both  `--parallel` and  `--max-concurrent`

### Changed
- Changed max test limit to 10 
