### PR TITLE
feat: add support for comparing against last update in update command

### DIFF
--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -338,6 +338,11 @@ def update(
         "--against-default",
         help="Compare against the default branch instead of HEAD",
     ),
+    against_last_update: bool = Option(
+        False,
+        "--against-last-update",
+        help="Compare against the commit from the last update run",
+    ),
 ):
     """Update your test specs with the latest changes."""
     from bugster.commands.update import update_command
@@ -348,6 +353,7 @@ def update(
         delete_only=delete_only,
         show_logs=show_logs,
         against_default=against_default,
+        against_last_update=against_last_update,
     )
 
 

--- a/bugster/commands/update.py
+++ b/bugster/commands/update.py
@@ -18,25 +18,52 @@ def update_command(
     delete_only: bool = False,
     show_logs: bool = False,
     against_default: bool = False,
+    against_last_update: bool = False,
 ):
     """Run Bugster CLI update command."""
     # Note: Logger configuration is now handled globally by the CLI
     # The --debug flag controls logging visibility across all commands
     # Legacy show_logs parameter is maintained for backward compatibility but is ignored
 
+    # Validate flags
+    if against_default and against_last_update:
+        console.print(
+            "[red]Error: Cannot use both --against-default and --against-last-update flags simultaneously[/red]"
+        )
+        raise typer.Exit(1)
+
     assert sum([update_only, suggest_only, delete_only]) <= 1, (
         "At most one of update_only, suggest_only, delete_only can be True"
     )
 
     try:
+        # Handle against_last_update logic
+        if against_last_update:
+            from bugster.libs.utils.update_tracker import has_last_update_state
+
+            if not has_last_update_state():
+                console.print(
+                    "[yellow]Warning: No previous update state found. Running against default branch instead.[/yellow]"
+                )
+                against_last_update = False
+                against_default = True
+
         console.print("✓ Analyzing code changes...")
         update_service = get_update_service(
             update_only=update_only,
             suggest_only=suggest_only,
             delete_only=delete_only,
             against_default=against_default,
+            against_last_update=against_last_update,
         )
         update_service.run()
+
+        # Save the current state after successful update
+        from bugster.libs.utils.update_tracker import save_update_state
+
+        save_update_state()
+        console.print("✓ Update state saved")
+
     except Exception as err:
         console.print(f"[red]Error: {str(err)}[/red]")
         raise typer.Exit(1)

--- a/bugster/constants.py
+++ b/bugster/constants.py
@@ -6,6 +6,7 @@ from pathlib import Path
 WORKING_DIR = Path.cwd()
 BUGSTER_DIR = WORKING_DIR / ".bugster"
 CONFIG_PATH = BUGSTER_DIR / "config.yaml"
+UPDATE_STATE_PATH = BUGSTER_DIR / ".update_state.json"
 TESTS_DIR = BUGSTER_DIR / "tests"
 
 # Ignore patterns for the .gitignore file

--- a/bugster/libs/mixins.py
+++ b/bugster/libs/mixins.py
@@ -95,12 +95,26 @@ class UpdateMixin:
         file_paths = self.mapped_changes["modified"]
         console.print(f"✓ Found {len(file_paths)} modified files")
 
-        # Choose git command based on against_default flag
-        git_command = (
-            GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_DEFAULT_LOCAL
-            if getattr(self, "against_default", False)
-            else GitCommand.DIFF_CHANGES_ONLY_MODIFIED
-        )
+        # Choose git command based on flags
+        if getattr(self, "against_last_update", False):
+            from bugster.libs.utils.update_tracker import get_last_update_commit
+
+            commit_hash = get_last_update_commit()
+            if commit_hash:
+                # Create command for diffing against specific commit
+                cmd_str = " ".join(
+                    GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_COMMIT
+                ).format(commit_hash=commit_hash)
+                git_command = cmd_str.split(" ")
+            else:
+                # Fallback to against default
+                git_command = (
+                    GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_DEFAULT_LOCAL
+                )
+        elif getattr(self, "against_default", False):
+            git_command = GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_DEFAULT_LOCAL
+        else:
+            git_command = GitCommand.DIFF_CHANGES_ONLY_MODIFIED
 
         diff_changes_per_page = get_diff_changes_per_page(
             import_tree=self.import_tree,
@@ -170,12 +184,24 @@ class SuggestMixin:
         file_paths = self.mapped_changes["new"]
         console.print(f"✓ Found {len(file_paths)} added files")
 
-        # Choose git command based on against_default flag
-        git_command = (
-            GitCommand.DIFF_AGAINST_DEFAULT_LOCAL
-            if getattr(self, "against_default", False)
-            else GitCommand.DIFF_HEAD
-        )
+        # Choose git command based on flags
+        if getattr(self, "against_last_update", False):
+            from bugster.libs.utils.update_tracker import get_last_update_commit
+
+            commit_hash = get_last_update_commit()
+            if commit_hash:
+                # Create command for diffing against specific commit
+                cmd_str = " ".join(GitCommand.DIFF_AGAINST_COMMIT).format(
+                    commit_hash=commit_hash
+                )
+                git_command = cmd_str.split(" ")
+            else:
+                # Fallback to against default
+                git_command = GitCommand.DIFF_AGAINST_DEFAULT_LOCAL
+        elif getattr(self, "against_default", False):
+            git_command = GitCommand.DIFF_AGAINST_DEFAULT_LOCAL
+        else:
+            git_command = GitCommand.DIFF_HEAD
 
         diff_changes_per_page = get_diff_changes_per_page(
             import_tree=self.import_tree, git_command=git_command

--- a/bugster/libs/mixins.py
+++ b/bugster/libs/mixins.py
@@ -97,10 +97,13 @@ class UpdateMixin:
 
         # Choose git command based on flags
         if getattr(self, "against_last_update", False):
-            from bugster.libs.utils.update_tracker import get_last_update_commit
+            from bugster.libs.utils.update_tracker import (
+                commit_exists,
+                get_last_update_commit,
+            )
 
             commit_hash = get_last_update_commit()
-            if commit_hash:
+            if commit_hash and commit_exists(commit_hash):
                 # Create command for diffing against specific commit
                 cmd_str = " ".join(
                     GitCommand.DIFF_CHANGES_ONLY_MODIFIED_AGAINST_COMMIT
@@ -186,10 +189,13 @@ class SuggestMixin:
 
         # Choose git command based on flags
         if getattr(self, "against_last_update", False):
-            from bugster.libs.utils.update_tracker import get_last_update_commit
+            from bugster.libs.utils.update_tracker import (
+                commit_exists,
+                get_last_update_commit,
+            )
 
             commit_hash = get_last_update_commit()
-            if commit_hash:
+            if commit_hash and commit_exists(commit_hash):
                 # Create command for diffing against specific commit
                 cmd_str = " ".join(GitCommand.DIFF_AGAINST_COMMIT).format(
                     commit_hash=commit_hash

--- a/bugster/libs/services/update_service.py
+++ b/bugster/libs/services/update_service.py
@@ -1,3 +1,4 @@
+import subprocess
 from abc import ABC, abstractmethod
 from typing import Optional
 
@@ -15,6 +16,7 @@ from bugster.libs.utils.git import (
     run_git_command,
 )
 from bugster.libs.utils.nextjs.import_tree_generator import generate_import_tree
+from bugster.libs.utils.update_tracker import get_last_update_commit
 
 
 class UpdateService(ABC):
@@ -24,11 +26,13 @@ class UpdateService(ABC):
         self,
         test_cases_service: Optional["TestCasesService"] = None,
         against_default: bool = False,
+        against_last_update: bool = False,
     ):
         self._test_cases_service = test_cases_service
         self._mapped_changes: Optional[dict] = None
         self._import_tree: Optional[dict] = None
         self.against_default = against_default
+        self.against_last_update = against_last_update
 
     @property
     def test_cases_service(self) -> TestCasesService:
@@ -53,7 +57,30 @@ class UpdateService(ABC):
 
     def _get_mapped_changes(self) -> dict:
         """Get the mapped changes of the user's repository."""
-        if self.against_default:
+        if self.against_last_update:
+            commit_hash = get_last_update_commit()
+            if not commit_hash:
+                # Fallback to against default if no commit hash found
+                diff_name_status = run_git_command(
+                    cmd_key=GitCommand.DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL
+                )
+                return parse_diff_name_status(diff_name_status=diff_name_status)
+
+            # Use GitCommand with commit hash following project pattern
+            cmd_str = " ".join(GitCommand.DIFF_NAME_STATUS_AGAINST_COMMIT).format(
+                commit_hash=commit_hash
+            )
+            cmd_list = cmd_str.split(" ")
+
+            result = subprocess.run(
+                cmd_list,
+                capture_output=True,
+                text=True,
+                check=True,
+                encoding="utf-8",
+            )
+            return parse_diff_name_status(diff_name_status=result.stdout)
+        elif self.against_default:
             # When comparing against default branch, use git diff --name-status
             diff_name_status = run_git_command(
                 cmd_key=GitCommand.DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL
@@ -126,13 +153,22 @@ def get_update_service(
     suggest_only: bool,
     delete_only: bool,
     against_default: bool = False,
+    against_last_update: bool = False,
 ):
     """Get the update service based on the flags."""
     if update_only:
-        return UpdateOnlyService(against_default=against_default)
+        return UpdateOnlyService(
+            against_default=against_default, against_last_update=against_last_update
+        )
     elif suggest_only:
-        return SuggestOnlyService(against_default=against_default)
+        return SuggestOnlyService(
+            against_default=against_default, against_last_update=against_last_update
+        )
     elif delete_only:
-        return DeleteOnlyService(against_default=against_default)
+        return DeleteOnlyService(
+            against_default=against_default, against_last_update=against_last_update
+        )
     else:
-        return DefaultUpdateService(against_default=against_default)
+        return DefaultUpdateService(
+            against_default=against_default, against_last_update=against_last_update
+        )

--- a/bugster/libs/services/update_service.py
+++ b/bugster/libs/services/update_service.py
@@ -16,7 +16,7 @@ from bugster.libs.utils.git import (
     run_git_command,
 )
 from bugster.libs.utils.nextjs.import_tree_generator import generate_import_tree
-from bugster.libs.utils.update_tracker import get_last_update_commit
+from bugster.libs.utils.update_tracker import commit_exists, get_last_update_commit
 
 
 class UpdateService(ABC):
@@ -59,8 +59,8 @@ class UpdateService(ABC):
         """Get the mapped changes of the user's repository."""
         if self.against_last_update:
             commit_hash = get_last_update_commit()
-            if not commit_hash:
-                # Fallback to against default if no commit hash found
+            if not commit_hash or not commit_exists(commit_hash):
+                # Fallback to against default if no commit hash found or commit doesn't exist
                 diff_name_status = run_git_command(
                     cmd_key=GitCommand.DIFF_NAME_STATUS_AGAINST_DEFAULT_LOCAL
                 )

--- a/bugster/libs/utils/enums.py
+++ b/bugster/libs/utils/enums.py
@@ -107,3 +107,35 @@ class GitCommand(list, Enum):
             "-- '*.tsx' '*.ts' '*.js' '*.jsx'"
         ),
     ]
+    DIFF_NAME_STATUS_AGAINST_COMMIT = [
+        "git",
+        "diff",
+        "--name-status",
+        "{commit_hash}",
+        "--",
+        "*.tsx",
+        "*.ts",
+        "*.js",
+        "*.jsx",
+    ]
+    DIFF_CHANGES_ONLY_MODIFIED_AGAINST_COMMIT = [
+        "git",
+        "diff",
+        "--diff-filter=M",
+        "{commit_hash}",
+        "--",
+        "*.tsx",
+        "*.ts",
+        "*.js",
+        "*.jsx",
+    ]
+    DIFF_AGAINST_COMMIT = [
+        "git",
+        "diff",
+        "{commit_hash}",
+        "--",
+        "*.tsx",
+        "*.ts",
+        "*.js",
+        "*.jsx",
+    ]

--- a/bugster/libs/utils/update_tracker.py
+++ b/bugster/libs/utils/update_tracker.py
@@ -74,3 +74,21 @@ def get_last_update_commit() -> Optional[str]:
 def has_last_update_state() -> bool:
     """Check if there's a previous update state."""
     return get_last_update_state() is not None
+
+
+def commit_exists(commit_hash: str) -> bool:
+    """Check if a commit hash exists in the repository."""
+    if not commit_hash:
+        return False
+
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-e", commit_hash],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        return result.returncode == 0
+    except subprocess.CalledProcessError:
+        return False

--- a/bugster/libs/utils/update_tracker.py
+++ b/bugster/libs/utils/update_tracker.py
@@ -1,0 +1,76 @@
+import json
+import subprocess
+from datetime import datetime
+from typing import Optional
+
+from bugster.constants import UPDATE_STATE_PATH
+
+
+def get_current_commit_hash() -> str:
+    """Get the current commit hash."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def get_current_branch() -> str:
+    """Get the current branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def save_update_state():
+    """Save the current update state to file."""
+    UPDATE_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    state = {
+        "timestamp": datetime.now().isoformat(),
+        "commit_hash": get_current_commit_hash(),
+        "branch": get_current_branch(),
+    }
+
+    with open(UPDATE_STATE_PATH, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2)
+
+
+def get_last_update_state() -> Optional[dict]:
+    """Get the last update state from file."""
+    if not UPDATE_STATE_PATH.exists():
+        return None
+
+    try:
+        with open(UPDATE_STATE_PATH, encoding="utf-8") as f:
+            state = json.load(f)
+        return state
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def get_last_update_commit() -> Optional[str]:
+    """Get the commit hash from the last update."""
+    state = get_last_update_state()
+    if state:
+        return state.get("commit_hash")
+    return None
+
+
+def has_last_update_state() -> bool:
+    """Check if there's a previous update state."""
+    return get_last_update_state() is not None


### PR DESCRIPTION
- Introduced a new CLI option `--against-last-update` to allow users to compare changes against the last update commit.
- Implemented logic to handle the new comparison option in the update command, including validation against the existing `--against-default` flag.
- Added utility functions to track and save the last update state, including the current commit hash and branch.
- Updated relevant services and mixins to support the new comparison functionality.