### PR TITLE
Release 0.3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Bugster CLI will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.30]
+
+### Added
+- `bugster config`  command
+This command will be used to access and manipulate the data inside config.yaml ( so as to avoid human error)
+
+Right now the only flag available is --bypass-protection. This will guide users on how to get the x-vercel-bypass-secret by re-directing them with the Deeplink cc: @giovaborgogno
+
+- `bugster install` command
+This command will be used to handle outside integrations with your Bugster account for users that dont want to switch context setting up the account ( especially during Manual Onboarding) 
+
+Right now the only flag available is --github. This will re-direct the user to the Github App Installation Link. I proposed to add a Terminal re-direction in further iterations after the installation process has been finished successfully.
+
+### Changed
+- Destructive Agent Limits
+Up to 4 as default. Later on we can parametrize with the subscription tiers
+Prioritization of UI crashers instead of Form Destroyers ( FD will run when all UI Crashers are ok)
+
 ## [0.3.26]
 
 ### Added

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -409,7 +409,7 @@ def destructive(
     headless: bool = Option(False, help="Run agents in headless mode"),
     silent: bool = Option(False, help="Run agents silently"),
     stream_results: bool = Option(
-        False, "--stream-results", help="Stream destructive results as they complete"
+        True, "--stream-results/--no-stream-results", help="Stream destructive results as they complete"
     ),
     base_url: Optional[str] = Option(None, help="Override base URL from config"),
     max_concurrent: Optional[int] = Option(
@@ -421,6 +421,12 @@ def destructive(
     verbose: bool = Option(False, help="Show detailed agent execution logs"),
     run_id: Optional[str] = Option(
         None, "--run-id", help="Run ID to associate with the destructive test run"
+    ),
+    limit: Optional[int] = Option(
+        None,
+        "--limit",
+        help="Maximum number of destructive agents to run (default: 5)",
+        min=1,
     ),
 ):
     """Run destructive agents to find potential bugs in changed pages."""
@@ -437,6 +443,7 @@ def destructive(
             max_concurrent,
             verbose,
             run_id,
+            limit,
         )
     )
 

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -440,6 +440,22 @@ def destructive(
         )
     )
 
+
+@app.command()
+def config(
+    bypass_protection: Optional[bool] = Option(
+        None,
+        "--bypass-protection",
+        flag_value=True,
+        help="Set Vercel protection bypass secret. Use without a value for interactive setup.",
+    ),      
+):
+    """Configure Bugster project settings."""
+    from bugster.commands.config import config_command
+
+    config_command(bypass_protection=bypass_protection)
+
+
 @app.command()
 def install(
     github: bool = Option(

--- a/bugster/cli.py
+++ b/bugster/cli.py
@@ -440,6 +440,20 @@ def destructive(
         )
     )
 
+@app.command()
+def install(
+    github: bool = Option(
+        False, "--github", help="Install GitHub App integration"
+    ),
+):
+    """Install integrations for your Bugster project."""
+    if github:
+        from bugster.commands.install import install_github_command
+        install_github_command()
+    else:
+        console.print("[red]Please specify an integration to install (e.g., --github)[/red]")
+        raise Exit(1)
+
 
 def main():
     app()

--- a/bugster/commands/config.py
+++ b/bugster/commands/config.py
@@ -1,0 +1,101 @@
+"""Config command implementation for Bugster CLI."""
+
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+import typer
+import yaml
+from rich.console import Console
+
+from bugster.analytics import track_command
+from bugster.constants import CONFIG_PATH
+from bugster.utils.file import load_config
+
+console = Console()
+
+VERCEL_PROTECTION_URL = "https://vercel.com/d?to=%2F%5Bteam%5D%2F%5Bproject%5D%2Fsettings%2Fdeployment-protection&title=Deployment+Protection+settings"
+
+
+
+
+def validate_bypass_protection_secret(secret: str) -> bool:
+    """Validate that the bypass protection secret is exactly 32 characters."""
+    return len(secret) == 32
+
+
+@track_command("config")
+def config_command(bypass_protection: Optional[bool] = None):
+    """Configure Bugster project settings."""
+    from rich.prompt import Confirm, Prompt
+
+    # Case 1: No flags provided, show help message
+    if bypass_protection is None:
+        console.print("Use --help to see available options.")
+        return
+
+    # Check for config file existence before proceeding
+    if not CONFIG_PATH.exists():
+        console.print(
+            "[red]Error: Configuration file not found. Please run 'bugster init' first.[/red]"
+        )
+        raise typer.Exit(1)
+
+    secret_to_save = None
+
+    # Case 2: --bypass-protection used without a value (interactive setup)
+    if bypass_protection:
+        console.print("\n[bold]Vercel Protection Bypass Configuration[/bold]\n")
+
+        if Confirm.ask(
+            "Would you like to get your Vercel bypass secret now?", default=True
+        ):
+            console.print(
+                "\n[bold cyan]Opening Vercel settings to help you find your secret...[/bold cyan]"
+            )
+            try:
+                webbrowser.open(VERCEL_PROTECTION_URL)
+                console.print(
+                    f"[dim]If your browser didn't open, please visit: {VERCEL_PROTECTION_URL}[/dim]\n"
+                )
+            except Exception:
+                console.print(
+                    f"[yellow]Please visit: {VERCEL_PROTECTION_URL} to get your secret.[/yellow]\n"
+                )
+
+            secret_to_save = Prompt.ask(
+                "Enter your 32-character Vercel protection bypass secret",
+                password=True,
+            )
+        else:
+            secret_to_save = Prompt.ask(
+                "\nPlease enter your 32-character Vercel protection bypass secret",
+                password=True,
+            )
+    # Case 3: --bypass-protection used with a value
+    else:
+        secret_to_save = bypass_protection
+
+    # Validate and save the secret
+    if not validate_bypass_protection_secret(secret_to_save):
+        console.print(
+            f"[red]Error: Bypass protection secret must be exactly 32 characters. "
+            f"Provided secret has {len(secret_to_save)} characters.[/red]"
+        )
+        raise typer.Exit(1)
+
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
+            config_data = yaml.safe_load(f)
+
+        config_data["x-vercel-protection-bypass"] = secret_to_save
+
+        with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+            yaml.dump(config_data, f, default_flow_style=False, sort_keys=False)
+
+        console.print(
+            "\n[green]✓ Vercel protection bypass secret has been saved to config.yaml[/green]"
+        )
+    except Exception as e:
+        console.print(f"[red]Error updating config file: {e}[/red]")
+        raise typer.Exit(1) 

--- a/bugster/commands/init.py
+++ b/bugster/commands/init.py
@@ -264,11 +264,11 @@ def init_command(
     # Project setup
     InitMessages.project_setup()
 
-    # Use provided project name or prompt for it
+    # Use provided project name or default to current directory name
     if project_name is None:
-        project_name = Prompt.ask("🏷️  Project name", default=Path.cwd().name)
-    else:
-        console.print(f"🏷️  Project name: {project_name}")
+        project_name = Path.cwd().name
+    
+    console.print(f"🏷️  Project name: {project_name}")
 
     project_path = ""
     with contextlib.suppress(Exception):

--- a/bugster/commands/install.py
+++ b/bugster/commands/install.py
@@ -1,0 +1,106 @@
+import time
+import webbrowser
+from typing import Optional
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from bugster.clients.http_client import BugsterHTTPClient, BugsterHTTPError
+from bugster.utils.user_config import get_api_key, extract_organization_id
+
+console = Console()
+
+
+def install_github_command():
+    """Install GitHub App integration."""
+    # Get API key
+    api_key = get_api_key()
+    if not api_key:
+        console.print("[red]❌ No API key found. Please run 'bugster auth' first.[/red]")
+        return
+
+    # Extract organization ID
+    try:
+        org_id = extract_organization_id(api_key)
+    except ValueError as e:
+        console.print(f"[red]❌ Error: {e}[/red]")
+        return
+
+    # Create HTTP client
+    client = BugsterHTTPClient()
+    client.set_auth_header(api_key)
+
+    try:
+        # Get installation URL
+        console.print("🔗 Getting GitHub installation URL...")
+        installation_url = client.get(f"/api/v1/github/installations/{org_id}/setup", params={"source": "cli"})
+        if not installation_url:
+            console.print("[red]❌ Failed to get installation URL[/red]")
+            return
+
+        console.print(f"📂 Opening GitHub installation page in your browser...")
+        console.print(f"🌐 URL: [blue]{installation_url}[/blue]")
+        
+        # Try to open in browser
+        try:
+            webbrowser.open(installation_url)
+        except Exception:
+            console.print("[yellow]⚠️  Could not automatically open browser. Please copy and paste the URL above.[/yellow]")
+
+        # Poll for installation completion
+        console.print("\n⏳ Waiting for GitHub installation to complete...")
+        console.print("💡 Complete the installation in your browser, then return here.")
+
+        timeout = 8 * 60  # 8 minutes in seconds
+        start_time = time.time()
+        poll_interval = 10  # Poll every 10 seconds
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task("Checking installation status...", total=None)
+            while time.time() - start_time < timeout:
+                try:
+                    repos_response = client.get(f"/api/v1/github/organizations/{org_id}/repositories")
+                    repositories = repos_response.get("repositories", [])
+                    if repositories:
+                        progress.stop()
+                        console.print("\n✅ [green]GitHub installation successful![/green]")
+                        console.print(f"📦 Found {len(repositories)} repositories connected.")
+                        
+                        # Show some repository details
+                        console.print("\n📋 Connected repositories:")
+                        for repo in repositories[:5]:  # Show first 5 repos
+                            repo_name = repo.get("repository_name", "Unknown")
+                            console.print(f"  • {repo_name}")
+                        
+                        if len(repositories) > 5:
+                            console.print(f"  ... and {len(repositories) - 5} more")
+                        
+                        return
+
+                except BugsterHTTPError:
+                    # Continue polling even if there's an API error
+                    pass
+                except Exception:
+                    # Continue polling for other errors too
+                    pass
+
+                time.sleep(poll_interval)
+
+        # Timeout reached
+        progress.stop()
+        console.print("\n❌ [red]Installation timeout reached (8 minutes).[/red]")
+        console.print("🔍 Something may have gone wrong during the GitHub installation.")
+        console.print("🌐 Please visit [blue]https://gui.bugster.dev[/blue] to complete the GitHub integration setup manually.")
+
+    except BugsterHTTPError as e:
+        console.print(f"[red]❌ API Error during GitHub installation: {e}[/red]")
+        console.print("🌐 Please visit [blue]https://gui.bugster.dev[/blue] to try installing the integration manually.")
+    except Exception as e:
+        console.print(f"[red]❌ Unexpected error during GitHub installation: {e}[/red]")
+        console.print("🌐 Please visit [blue]https://gui.bugster.dev[/blue] to try installing the integration manually.")
+    finally:
+        client.close()

--- a/bugster/libs/services/destructive_limits_service.py
+++ b/bugster/libs/services/destructive_limits_service.py
@@ -166,7 +166,7 @@ def get_destructive_limit_from_config() -> Optional[int]:
             return config.preferences.destructive_limit
 
         # Default limit for destructive agents
-        return 2
+        return 4
     except Exception:
         # If config loading fails, return default
-        return 2
+        return 4

--- a/bugster/libs/services/destructive_limits_service.py
+++ b/bugster/libs/services/destructive_limits_service.py
@@ -1,0 +1,172 @@
+"""
+Destructive agent limit logic for Bugster CLI
+"""
+
+from collections import defaultdict
+from typing import List, Optional, Tuple
+
+
+# Agent priority order (higher number = higher priority)
+AGENT_PRIORITIES = {
+    "UI Crashers": 2,
+    "From Destroyer": 1,
+}
+
+
+def apply_destructive_agent_limit(
+    page_agent_tuples: List[Tuple[str, str, str]], max_agents: Optional[int] = None
+) -> Tuple[List[Tuple[str, str, str]], dict]:
+    """
+    Apply destructive agent limit logic to select a representative subset of agents.
+
+    Args:
+        page_agent_tuples: List of (page, agent, diff) tuples
+        max_agents: Maximum number of agents to run (if None, no limit)
+
+    Returns:
+        Tuple of (limited list of agent tuples, agent type distribution dict)
+    """
+    if max_agents is None:
+        return page_agent_tuples, {}
+
+    total_agents = len(page_agent_tuples)
+
+    if total_agents <= max_agents:
+        return page_agent_tuples, {}
+
+    # Group agents by type and apply prioritization
+    selected_agents, agent_distribution = select_prioritized_agents(
+        page_agent_tuples, max_agents
+    )
+
+    return selected_agents, agent_distribution
+
+
+def group_agents_by_type(
+    page_agent_tuples: List[Tuple[str, str, str]]
+) -> dict[str, List[Tuple[str, str, str]]]:
+    """
+    Group agents by their type.
+
+    Args:
+        page_agent_tuples: List of (page, agent, diff) tuples
+
+    Returns:
+        Dictionary mapping agent types to lists of agent tuples
+    """
+    agent_groups = defaultdict(list)
+
+    for page, agent, diff in page_agent_tuples:
+        # Determine agent type based on agent name
+        agent_type = get_agent_type(agent)
+        agent_groups[agent_type].append((page, agent, diff))
+
+    return dict(agent_groups)
+
+
+def get_agent_type(agent_name: str) -> str:
+    """
+    Determine agent type from agent name.
+
+    Args:
+        agent_name: Name of the agent
+
+    Returns:
+        Agent type string
+    """
+    # Map agent names to types based on known patterns
+    if "UI Crashers" in agent_name or "ui_crasher" in agent_name.lower():
+        return "UI Crashers"
+    elif "From Destroyer" in agent_name or "destroyer" in agent_name.lower():
+        return "From Destroyer"
+    else:
+        # Unknown agent type gets lowest priority
+        return "Other"
+
+
+def select_prioritized_agents(
+    page_agent_tuples: List[Tuple[str, str, str]], max_agents: int
+) -> Tuple[List[Tuple[str, str, str]], dict]:
+    """
+    Select agents based on strict priority order: ALL UI Crashers first, then From Destroyer, then Others.
+
+    Args:
+        page_agent_tuples: List of (page, agent, diff) tuples
+        max_agents: Maximum number of agents to select
+
+    Returns:
+        Tuple of (list of selected agent tuples, agent type distribution dict)
+    """
+    # Group agents by type
+    agent_groups = group_agents_by_type(page_agent_tuples)
+    
+    if not agent_groups:
+        return [], {}
+
+    # Sort agent types by priority (highest first)
+    sorted_agent_types = sorted(
+        agent_groups.keys(),
+        key=lambda x: AGENT_PRIORITIES.get(x, 0),
+        reverse=True
+    )
+
+    selected_agents = []
+    agent_distribution = {}
+    remaining_slots = max_agents
+
+    # Select ALL agents from each type in strict priority order
+    for agent_type in sorted_agent_types:
+        if remaining_slots <= 0:
+            break
+            
+        available_agents = agent_groups[agent_type]
+        
+        # Take as many agents as possible from this type (up to remaining slots)
+        agents_to_take = min(len(available_agents), remaining_slots)
+        
+        if agents_to_take > 0:
+            selected_agents.extend(available_agents[:agents_to_take])
+            agent_distribution[agent_type] = agents_to_take
+            remaining_slots -= agents_to_take
+
+    return selected_agents[:max_agents], agent_distribution
+
+
+def count_total_agents(page_agent_tuples: List[Tuple[str, str, str]]) -> int:
+    """
+    Count total number of destructive agents.
+
+    Args:
+        page_agent_tuples: List of (page, agent, diff) tuples
+
+    Returns:
+        Total number of agents
+    """
+    return len(page_agent_tuples)
+
+
+def get_destructive_limit_from_config() -> Optional[int]:
+    """
+    Get destructive agent limit from configuration.
+
+    Returns:
+        Maximum number of agents to run, or None if no limit
+    """
+    try:
+        from bugster.utils.file import load_config
+
+        config = load_config()
+
+        # Check if limit is configured in preferences.destructive_limit
+        if (
+            config.preferences 
+            and hasattr(config.preferences, 'destructive_limit') 
+            and config.preferences.destructive_limit is not None
+        ):
+            return config.preferences.destructive_limit
+
+        # Default limit for destructive agents
+        return 2
+    except Exception:
+        # If config loading fails, return default
+        return 2

--- a/bugster/utils/user_config.py
+++ b/bugster/utils/user_config.py
@@ -34,23 +34,36 @@ def save_user_config(config: dict) -> None:
     """Save configuration to file."""
     config_file = get_user_config_file()
 
-    # Create parent directories if they don't exist
     config_file.parent.mkdir(parents=True, exist_ok=True)
 
     with open(config_file, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)
 
+def extract_organization_id(api_key: str) -> str:
+    if not api_key.startswith("bugster_"):
+        raise ValueError("Invalid API key format: must start with 'bugster_'")
+
+    without_prefix = api_key[8:]
+
+    if (
+        len(without_prefix) <= 32
+    ):
+        raise ValueError("Invalid API key format: insufficient length")
+
+    organization_id = without_prefix[16:-16]
+    if not organization_id:
+        raise ValueError("Invalid API key format: no organization ID found")
+    organization_id = "org_" + organization_id
+    return organization_id
 
 def get_api_key() -> Optional[str]:
     """Get API key from environment or config file."""
-    # First check environment variable
     api_key = os.getenv(ENV_API_KEY)
 
     if api_key:
         logger.info("API key found in environment variable")
         return api_key
 
-    # Then check config file
     config = load_user_config()
     logger.info("API key found in config file")
     return config.get("apiKey")


### PR DESCRIPTION
## `bugster config` command
- This command will be used to access and manipulate the data inside config.yaml ( so as to avoid human error)
- Right now the only flag available is --bypass-protection. This will guide users on how to get the x-vercel-bypass-secret by re-directing them with the Deeplink cc: @giovaborgogno 

## `bugster install` command
- This command will be used to handle outside integrations with your Bugster account for users that dont want to switch context setting up the account ( especially during Manual Onboarding) 
- Right now the only flag available is --github. This will re-direct the user to the Github App Installation Link. I proposed to add a Terminal re-direction in further iterations after the installation process has been finished successfully.


## Destructive Agent Limits

- Up to 4 as default. Later on we can parametrize with the subscription tiers
- Prioritization of UI crashers instead of Form Destroyers ( FD will run when all UI Crashers are ok)
### **Example scenarios:**
**Scenario 1**: Limit of 4 agents
Available: 6 UI Crashers, 3 Form Destroyers, 2 Others
Selected: 4 UI Crashers (none of the others get selected)

**Scenario 2**: Limit of 4 agents
Available: 2 UI Crashers, 5 Form Destroyers, 3 Others
Selected: 2 UI Crashers + 2 Form Destroyers

**Scenario 3**: Limit of 4 agents
Available: 1 UI Crasher, 1 Form Destroyer, 8 Others
Selected: 1 UI Crasher + 1 Form Destroyer + 2 Others