### PR TITLE
refactor: remove unused import in test command

### DIFF
--- a/bugster/commands/test.py
+++ b/bugster/commands/test.py
@@ -955,8 +955,6 @@ async def test_command(
         RunMessages.error(e)
         raise typer.Exit(1) from None
     finally:
-        from bugster.utils.file import load_config
-
         is_first_run = check_and_update_project_commands(command_name="test")
         config = load_config()
         project_id = config.project_id


### PR DESCRIPTION
- Eliminated the import of `load_config` from the `test.py` file, streamlining the code and improving clarity.